### PR TITLE
Ensure existence of full saving path

### DIFF
--- a/kiosk_browser/main.py
+++ b/kiosk_browser/main.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import os
 import subprocess
 from ajenti.api import *
 from ajenti.plugins.main.api import SectionPlugin

--- a/kiosk_browser/main.py
+++ b/kiosk_browser/main.py
@@ -58,4 +58,11 @@ class SanickioskScreensaverPrefs (SectionPlugin):
 			"Comment[en_US]=\n"
 			"Comment=") % (home_url, enable_browser)
         
-        	open('/home/kiosk/.config/autostart/2-browser.desktop', 'w').write(cfg) #save
+        	filename = '/home/kiosk/.config/autostart/2-browser.desktop'
+        	if not os.path.exists(os.path.dirname(filename)):
+        		try:
+        			os.makedirs(os.path.dirname(filename))
+        		except OSError as exc:
+        			if exc.errno != errno.EEXIST:
+        				raise
+        	open(filename, 'w').write(cfg) #save


### PR DESCRIPTION
@mmihalev Doing some experiments with a fresh installation I realized that the "autostart" directory might not exist. This can cause errors when saving, so I added a few lines to make sure that the full path exists.
